### PR TITLE
Add Traefik port reconciliation playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Verifique:
 - Desmonta volúmenes.
 - Borra LVM y particiones.
 - Seguro para reprovisionar nodos.
+### 🚗 `fix_traefik_port.yml`
+- Reconcilia los puertos del Service de Traefik para exponer el dashboard.
+- Si gestionas Traefik con Helm, ejecuta `helm upgrade` tras aplicar este playbook.
 
 ---
 
@@ -245,6 +248,7 @@ flatcar-k3s-storage-suite/
 │   ├── 03_generate-selfsigned-certs.yml    # Certificados autofirmados
 │   ├── 04_generate-auth-secret.yml         # Autenticación básica
 │   ├── 05_ingress-longhorn-internal.yml    # IngressRoute + middleware
+│   ├── fix_traefik_port.yml                # Reconcilia puertos del Service
 │   ├── 99_cleanup-longhorn.yml             # Limpieza completa
 │
 │   └── templates/

--- a/playbooks/fix_traefik_port.yml
+++ b/playbooks/fix_traefik_port.yml
@@ -1,0 +1,21 @@
+# playbooks/fix_traefik_port.yml
+---
+- name: 🔧  - Asegurar que Traefik exponga el puerto del dashboard
+  hosts: localhost
+  become: false
+  gather_facts: false
+
+  tasks:
+    - name: Ensure Traefik exposes dashboard port
+      kubernetes.core.k8s:
+        kind: Service
+        namespace: kube-system
+        name: traefik
+        merge_type: merge
+        resource_definition:
+          spec:
+            ports:
+              - name: traefik
+                port: 9000
+                protocol: TCP
+                targetPort: 9000


### PR DESCRIPTION
## Summary
- add `fix_traefik_port.yml` to patch the Traefik Service
- document the new playbook in the README

## Testing
- `ansible-playbook --syntax-check playbooks/fix_traefik_port.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517fba66e08327ba7dcfbf05619e7a