### PR TITLE
Fix variable mismatch for domain

### DIFF
--- a/inventory/hosts.ini
+++ b/inventory/hosts.ini
@@ -19,5 +19,5 @@
 
 [all:vars]
 k3s_master_ip=10.17.4.21
-traefik_domain=traefik.local
+domain=traefik.local
 letsencrypt_email=tu-email@dominio.com


### PR DESCRIPTION
## Summary
- rename `traefik_domain` to `domain` in `hosts.ini`

## Testing
- `ansible-playbook playbooks/05_ingress-longhorn-internal.yml --syntax-check -i inventory/hosts.ini` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517fc275648327a27e55529ff9fd4f