### PR TITLE
Fix ansible roles configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,15 @@ Verifique:
 
 ## 📘 Tareas y su Descripción
 
-### 🧱 `storage_setup` (Rol)
-- Verificación segura de `/dev/vdb`.
-- Particionado y creación de VG + LVs.
-- Montaje y formateo.
-- Exportación NFS.
+### 🧱 Preparación de discos
+ - Verificación segura de `/dev/vdb`.
+ - Particionado y creación de VG + LVs.
+ - Montaje y formateo.
+ - Exportación NFS.
 
-### 💾 `longhorn_worker` (Rol)
-- Verificación segura de `/dev/vdb`.
-- Formateo y montaje en `/mnt/longhorn-disk`.
+### 💾 Configuración de Longhorn
+ - Verificación segura de `/dev/vdb`.
+ - Formateo y montaje en `/mnt/longhorn-disk`.
 
 ### 🚀 `install_longhorn.yml`
 - Etiquetado de nodos.

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,8 +2,6 @@
 # Ruta al archivo de inventario
 inventory = inventory/hosts.ini
 
-# Ruta a los roles personalizados
-roles_path = ./roles
 
 # Usuario por defecto en nodos Flatcar
 remote_user = core


### PR DESCRIPTION
## Summary
- remove unused `roles_path` option from `ansible.cfg`
- clarify that there are no roles in README

## Testing
- `ansible-playbook --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517fce528c832792fd6d6f869a6b75